### PR TITLE
Export RSWT and WriterT constructor

### DIFF
--- a/Control/Monad/RWS/CPS.hs
+++ b/Control/Monad/RWS/CPS.hs
@@ -30,7 +30,7 @@ module Control.Monad.RWS.CPS (
   mapRWS,
   withRWS,
   -- * The RWST monad transformer
-  RWST,
+  RWST(..),
   runRWST,
   evalRWST,
   execRWST,

--- a/Control/Monad/Writer/CPS.hs
+++ b/Control/Monad/Writer/CPS.hs
@@ -27,7 +27,7 @@ module Control.Monad.Writer.CPS (
   execWriter,
   mapWriter,
   -- * The WriterT monad transformer
-  WriterT,
+  WriterT(..),
   runWriterT,
   execWriterT,
   mapWriterT,

--- a/writer-cps-monads-tf.cabal
+++ b/writer-cps-monads-tf.cabal
@@ -3,7 +3,7 @@
 -- see: https://github.com/sol/hpack
 
 name:           writer-cps-monads-tf
-version:        0.1.0.0
+version:        0.1.0.1
 synopsis:       MonadWriter orphan instances for writer-cps-transformers
 description:    The WriterT and RWST monad transformers provided by writer-cps-transformers are written in continuation passing style and avoid the space-leak problem of the traditional Control.Monad.Trans.Writer.Strict and Control.Monad.Trans.Writer.Lazy. See also (<http://hackage.haskell.org/package/writer-cps-transformers>).
 category:       Control


### PR DESCRIPTION
Hi, thanks for creating this package, but I couldn't use it because the constructor isn't exported.
I think they are supposed to be exported. See

https://hackage.haskell.org/package/transformers-0.5.2.0/docs/src/Control.Monad.Trans.RWS.Strict.html

https://hackage.haskell.org/package/transformers-0.5.2.0/docs/src/Control.Monad.Trans.Writer.Strict.html